### PR TITLE
Updated wmi query to catch version 6.x.x

### DIFF
--- a/powershell-scripts/twingate_client_installer.ps1
+++ b/powershell-scripts/twingate_client_installer.ps1
@@ -14,18 +14,18 @@ $twingateNetworkName = "networkname" #this is the name of the network in Twingat
 
 # Check to see if the .NET Desktop Runtime 6.0 is already installed
 Write-Host [+] Checking if .NET Desktop Runtime 6.0 is already installed
-$dotnetRuntime = Get-WmiObject -Query "SELECT * FROM Win32_Product WHERE Name LIKE '%.NET%Runtime%6%'"
+$dotnetRuntime = Get-WmiObject -Query "SELECT * FROM Win32_Product WHERE Name LIKE '%.NET%Runtime%6.%.%'"
 if ($dotnetRuntime -ne $null) {
     Write-Host [+] .NET Desktop Runtime 6.0 is already installed
 } else {
     # Installing the .NET Desktop Runtime
     Write-Host [+] .NET Desktop Runtime 6.0 is not installed
     Write-Host [+] Downloading .NET Desktop Runtime
-    $AgentURI = 'https://download.visualstudio.microsoft.com/download/pr/3ef3cd0c-8c7f-4146-bd8d-589d748b997e/3477d059f8fe5cceb5166b367d7995c6/windowsdesktop-runtime-6.0.27-win-x64.exe'
-    $AgentDest = 'C:\Windows\Temp\windowsdesktop-runtime-6.0.29-win-x64.exe'
+    $AgentURI = 'https://download.visualstudio.microsoft.com/download/pr/a1da19dc-d781-4981-84e9-ffa0c05e00e9/46f3cd2015c27a0e93d7c102a711577e/windowsdesktop-runtime-6.0.31-win-x64.exe'
+    $AgentDest = 'C:\Windows\Temp\windowsdesktop-runtime-6.0.31-win-x64.exe'
     Invoke-WebRequest $AgentURI -OutFile $AgentDest -UseBasicParsing
     Write-Host [+] Installing the .NET Desktop Runtime
-    cmd /c "C:\Windows\Temp\windowsdesktop-runtime-6.0.29-win-x64.exe /install /quiet /norestart"
+    cmd /c "C:\Windows\Temp\windowsdesktop-runtime-6.0.31-win-x64.exe /install /quiet /norestart"
     Write-Host [+] Finished installing .NET Desktop Runtime
 }
 


### PR DESCRIPTION
Fixed wmi query false matching the 6 in the architecture designation
Updated to grab latest dotnet 6 version 6.0.31 from 6.0.27

Original query - Get-WmiObject -Query "SELECT * FROM Win32_Product WHERE Name LIKE '%.NET%Runtime%6%'"
![image](https://github.com/Twingate-Solutions/general-scripts/assets/25190081/9ccb63ae-59d4-4d7f-a0b5-ed225c71b6f1)

Fixed query - Get-WmiObject -Query "SELECT * FROM Win32_Product WHERE Name LIKE '%.NET%Runtime%6.%.%'"
![image](https://github.com/Twingate-Solutions/general-scripts/assets/25190081/c3e4df0d-94fa-4546-b528-65c3d4614735)

