### PR TITLE
Optimize twingate_client_installer.ps1

### DIFF
--- a/powershell-scripts/twingate_client_installer.ps1
+++ b/powershell-scripts/twingate_client_installer.ps1
@@ -136,7 +136,7 @@ if ((Get-Process -Name "Twingate" -ErrorAction SilentlyContinue) -And (Get-Servi
 # This is useful if you want to ensure a clean install
 if ($uninstallFirst) {
     Write-Host [+] Uninstall flag set, uninstalling Twingate Client application
-    $twingateApp = Get-WmiObject -Class Win32_Product | Where-Object{$_.Name.Contains("Twingate")}
+    $twingateApp = Get-WmiObject -Class Win32_Product -Filter 'Name LIKE "%Twingate%"'
     if ($twingateApp) {
         $twingateApp.Uninstall()
     }
@@ -145,7 +145,7 @@ if ($uninstallFirst) {
 # Check to see if the .NET Desktop Runtime 6.0 is already installed
 Write-Host [+] Checking if .NET Desktop Runtime 6.0 is already installed
 $dotnetRuntime = Get-WmiObject -Query "SELECT * FROM Win32_Product WHERE Name LIKE '%.NET%Runtime%6.%.%'"
-if ($dotnetRuntime -ne $null) {
+if ($null -ne $dotnetRuntime) {
     Write-Host [+] .NET Desktop Runtime 6.0 is already installed
 } else {
     # Installing the .NET Desktop Runtime
@@ -162,7 +162,7 @@ if ($dotnetRuntime -ne $null) {
 # Check to see if the .NET Desktop Runtime 8.0 is already installed
 Write-Host [+] Checking if .NET Desktop Runtime 8.0 is already installed
 $dotnetRuntime = Get-WmiObject -Query "SELECT * FROM Win32_Product WHERE Name LIKE '%.NET%Runtime%8.%.%'"
-if ($dotnetRuntime -ne $null) {
+if ($null -ne $dotnetRuntime) {
     Write-Host [+] .NET Desktop Runtime 8.0 is already installed
 } else {
     # Installing the .NET Desktop Runtime


### PR DESCRIPTION
Minor changes.

1. Change Twingate uninstall WMI query to a filter expression in WMI rather than piping to where-object. This increases speed of the operation significantly as the WMI database query is filtered and the returned result set is smaller, as opposed to pulling all w32_products from the WMI database then filtering the results post-facto.

2. Change null comparisons to have null on the left side of the equality test. PowerShell can be inconsistent with null comparisons if null is on the right side. See: https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/rules/possibleincorrectcomparisonwithnull?view=ps-modules