### PR TITLE
Installer/uninstaller updates

### DIFF
--- a/powershell-scripts/twingate_client_installer.ps1
+++ b/powershell-scripts/twingate_client_installer.ps1
@@ -174,7 +174,7 @@ $AgentURI = 'https://api.twingate.com/download/windows?installer=msi'
 $AgentDest = 'C:\Windows\Temp\TwingateInstaller.msi'
 Invoke-WebRequest $AgentURI -OutFile $AgentDest -UseBasicParsing
 Write-Host [+] Installing the Twingate Client
-cmd /c "msiexec.exe /i C:\Windows\Temp\TwingateInstaller.msi /qn network=$twingateNetworkName.twingate.com no_optional_updates=true"
+cmd /c "msiexec.exe /i C:\Windows\Temp\TwingateInstaller.msi /qn network=$twingateNetworkName.twingate.com no_optional_updates=true auto_update=true"
 Write-Host [+] Finished installing Twingate Client
 
 # If the createMachineKey variable is set to true, then create the machinekey.conf file

--- a/powershell-scripts/twingate_client_uninstaller.ps1
+++ b/powershell-scripts/twingate_client_uninstaller.ps1
@@ -31,9 +31,27 @@ if ((Get-Process -Name "Twingate" -ErrorAction SilentlyContinue) -And (Get-Servi
 Write-Host [+] Uninstalling Twingate
 $twingateApp = Get-WmiObject -Class Win32_Product | Where-Object{$_.Name.Contains("Twingate")}
 if ($twingateApp) {
+    Write-Host [+] $twingateApp found uninstalling now
     $twingateApp.Uninstall()
 } else {
     Write-Host [+] Twingate is not installed
+}
+
+# Check for and remove any of the scheduled tasks
+Write-Host [+] Checking for scheduled tasks
+if (Get-ScheduledTask -TaskName "Twingate Client Auto Update" -ErrorAction SilentlyContinue) {
+    Write-Host [+] Auto update task exists, removing it
+    Unregister-ScheduledTask -TaskName "Twingate Client Auto Update" -Confirm:$false
+}
+
+if (Get-ScheduledTask -TaskName "Twingate Client Restart" -ErrorAction SilentlyContinue) {
+    Write-Host [+] Scheduled Task exists, removing it
+    Unregister-ScheduledTask -TaskName "Twingate Client Restart" -Confirm:$false
+}
+
+if (Get-ScheduledTask -TaskName "Twingate User Logged Out Notification" -ErrorAction SilentlyContinue) {
+    Write-Host [+] User Logged In scheduled task exists, removing it
+    Unregister-ScheduledTask -TaskName "Twingate User Logged Out Notification" -Confirm:$false
 }
 
 # Check if the Twingate ProgramData folder exists
@@ -43,7 +61,6 @@ if (Test-Path $twingateProgramData) {
 } else {
     Write-Host [+] Twingate ProgramData folder does not exist
 }
-
 
 # Finished running the script
 Write-Host [+] Finished running Twingate Client uninstaller script


### PR DESCRIPTION
Installer:
- Added the "auto_update=true" flag to the client install command, which unintuitively does NOT trigger automatic updates, but instead prevents the active session from being reset during a live update.  This should make things a bit easier on end users.

Uninstaller:
- Added blocks to check for and remove any possible scheduled tasks created by the installer script, to stop them from running