### PR TITLE
Bc/ubuntu client installer

### DIFF
--- a/bash-scripts/README.md
+++ b/bash-scripts/README.md
@@ -5,3 +5,6 @@ The scripts in this folder are meant to be used as the basis of scripts that can
 ## Scripts
 
 - **`user_not_logged_in_notification.sh`**: Bash script to automate sending a notification to a user when they are not logged in to the Twingate Client application. This script can be used to remind users to log in to the Twingate Client application, and to provide them with instructions on how to do so. Requires **`template_com.twingate.logincheck.plist`** if automating via launchd is needed.
+- **`client_linux_firewall_check.sh`**: Bash script to check the state of the firewall and report it back to the user.
+- **`client_macos_sys-info.sh`**: Bash script to be run on a MacOS system, to gather various system information and put into a file for sending to Twingate support for troubleshooting.
+- **`ubuntu-client-installer.sh`**: Bash script to install the Twingate client on an Ubuntu system, and also to configure special DNS settings.

--- a/bash-scripts/ubuntu-client-installer.sh
+++ b/bash-scripts/ubuntu-client-installer.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Set local variables
+dns_servers="1.2.3.4 5.6.7.8" #set your DNS servers here, space separated
+dns_search_domain="company.internal" #set your search domains/suffixes here
+
+ubuntu_version=$(lsb_release -rs)
+echo "Ubuntu Version: $ubuntu_version"
+
+# Try to figure out systemd-resolved vs NetworkManager
+active_manager=""
+if systemctl is-active --quiet NetworkManager; then
+    active_manager="NetworkManager"
+elif systemctl is-active --quiet systemd-networkd; then
+    active_manager="systemd-networkd"
+else
+    active_manager="Unknown" # If neither in use then bail out later, can't do ifupdown yet
+fi
+
+echo "Active Network Manager: $active_manager"
+
+# Function to configure the DNS settings 
+configure_dns() {
+    case $active_manager in
+    "systemd-networkd")
+        if systemctl is-active --quiet systemd-resolved; then # Let's assume systemd-resolved is in use
+            echo "systemd-resolved is running"
+            resolved_config="/etc/systemd/resolved.conf"
+            if [ -f "$resolved_config" ]; then
+                echo "Updating systemd-resolved configuration..."
+                sed -i '/^DNS=/d' "$resolved_config"
+                sed -i '/^Domains=/d' "$resolved_config"
+                echo -e "DNS=$dns_servers\nDomains=$dns_search_domain\nDNSStubListener=no\nResolveUnicastSingleLabel=yes" >> "$resolved_config"
+                systemctl restart systemd-resolved
+                echo "systemd-resolved configuration updated and service restarted."
+            else
+                echo "systemd-resolved configuration file not found!"
+                exit 1
+            fi
+        fi
+        ;;
+    "NetworkManager")
+        # Just in case there's several connections let's update all of them
+        nmcli con show | tail -n +2 | awk '{print $1}' | while read -r connection; do
+            echo "Updating DNS for NetworkManager connection: $connection"
+            nmcli con mod "$connection" ipv4.dns "$dns_servers" ipv4.dns-search "$dns_search_domain"
+            nmcli con down "$connection" && nmcli con up "$connection"
+        done
+        ;;
+    *)
+        echo "Unsupported network manager: $active_manager"
+        exit 1
+        ;;
+    esac
+}
+
+configure_dns
+
+# Install the Twingate client now
+curl -s https://binaries.twingate.com/client/linux/install.sh | sudo bash

--- a/bash-scripts/ubuntu-client-installer.sh
+++ b/bash-scripts/ubuntu-client-installer.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Purpose of this script is to first install the Twingate client, and then to configure custom DNS settings.
+# There are cases where due to unique internal DNS structures it is necessary to set static DNS resolvers
+# and a search domain. This script will configure the DNS settings for systemd-resolved or NetworkManager
+# based on the active network manager in use.
+
+# If you don't need these custom settings then just install the Twingate client app normally.
+
+
 # Set local variables
 dns_servers="1.2.3.4 5.6.7.8" #set your DNS servers here, space separated
 dns_search_domain="company.internal" #set your search domains/suffixes here
@@ -54,7 +62,9 @@ configure_dns() {
     esac
 }
 
-configure_dns
 
 # Install the Twingate client now
 curl -s https://binaries.twingate.com/client/linux/install.sh | sudo bash
+
+# Configure the DNS settings
+configure_dns


### PR DESCRIPTION
Adding the Ubuntu client installer script, which is helpful in a situation where special DNS settings are needed and you want to automate deployment of those settings alongside the Twingate app.