### PR TITLE
Adding support for the NextDNS root cert

### DIFF
--- a/powershell-scripts/twingate_client_installer.ps1
+++ b/powershell-scripts/twingate_client_installer.ps1
@@ -78,6 +78,12 @@ $autoUpdateTaskDescription = "This task will check every $updateDays days to see
 $addDNSSearchDomain = $false
 $dnsSearchDomain = "test.domain.com"
 
+
+# If you are using the Twingate DNS Filtering service and would like to avoid issues with the block page failing in some situations
+# you can install the NextDNS root certificate.  This is optional, and only necessary if you are using the Twingate DNS Filtering service
+# and are experiencing issues with the block page not loading properly.
+$installRootCert = $false
+
 ###################################
 ##         Set Variables         ##
 ###################################
@@ -349,6 +355,13 @@ if ($addDNSSearchDomain) {
     } else {
         Write-Host [+] Twingate TAP adapter not found, skipping DNS search domain addition
     }
+}
+
+# Install the NextDNS root cert if enabled
+if ($installRootCert) {
+    Invoke-WebRequest -Uri "https://nextdns.io/ca" -OutFile "$env:TEMP\nextdns.cer"
+    certutil -addstore -f root "$env:TEMP\nextdns.cer"
+    Remove-Item "$env:TEMP\nextdns.cer"
 }
 
 # Finished running the script

--- a/powershell-scripts/twingate_client_uninstaller.ps1
+++ b/powershell-scripts/twingate_client_uninstaller.ps1
@@ -62,6 +62,10 @@ if (Test-Path $twingateProgramData) {
     Write-Host [+] Twingate ProgramData folder does not exist
 }
 
+# Remove the NextDNS Root Cert if it exists
+Write-Host [+] Removing the NextDNS Root Cert
+certutil –delstore Root d47605fc0736802cee4153dda032d276cf2c81c7
+
 # Finished running the script
 Write-Host [+] Finished running Twingate Client uninstaller script
 


### PR DESCRIPTION
There are some situations where the DNS filtering block page will not load properly due to HTTPS -> HTTP downgrade, and either the browser extension or the NextDNS root certificate is needed to resolve.

As this is a third party certificate not handled by Twingate, there needs to be a way to both install and uninstall it later on if necessary, so adding it to both scripts.