### PR TITLE
Uninstaller update

### DIFF
--- a/powershell-scripts/twingate_client_installer.ps1
+++ b/powershell-scripts/twingate_client_installer.ps1
@@ -82,6 +82,10 @@ $dnsSearchDomain = "test.domain.com"
 # If you are using the Twingate DNS Filtering service and would like to avoid issues with the block page failing in some situations
 # you can install the NextDNS root certificate.  This is optional, and only necessary if you are using the Twingate DNS Filtering service
 # and are experiencing issues with the block page not loading properly.
+
+# Note: The NextDNS root certificate is not managed by Twingate, it is managed by NextDNS as a vendor of Twingate.
+# If you have concerns around the security of a third-party root certificate please see their 
+# documentation for more information: https://help.nextdns.io/t/g9hmv0a?r=m1htlfl
 $installRootCert = $false
 
 ###################################

--- a/powershell-scripts/twingate_client_uninstaller.ps1
+++ b/powershell-scripts/twingate_client_uninstaller.ps1
@@ -29,6 +29,13 @@ if ((Get-Process -Name "Twingate" -ErrorAction SilentlyContinue) -And (Get-Servi
 }
 
 Write-Host [+] Uninstalling Twingate
+Write-Host [+] Uninstall flag set, uninstalling Twingate Client application
+$twingateApp = Get-WmiObject -Class Win32_Product -Filter 'Name LIKE "%Twingate%"'
+if ($twingateApp) {
+    $twingateApp.Uninstall()
+}
+
+
 $twingateApp = Get-WmiObject -Class Win32_Product | Where-Object{$_.Name.Contains("Twingate")}
 if ($twingateApp) {
     Write-Host [+] $twingateApp found uninstalling now


### PR DESCRIPTION
Changed the method of identifying if the Twingate client is installed as an app to try to work around an issue where if the app is not installed it throws an error, which breaks Intune's reporting.