### PR TITLE
Adding method to stay behind a version

### DIFF
--- a/powershell-scripts/detect-installed-client-out-of-date.ps1
+++ b/powershell-scripts/detect-installed-client-out-of-date.ps1
@@ -8,6 +8,10 @@
 # It is meant to be run via Powershell 5.x on Windows 10 or 11, and parts may not function on other versions of Windows
 # or Powershell.  It is recommended to test this script in a lab environment before deploying to production.
 
+# Variables
+$versionsToStayBehind = 0  # Set to a number greater than 0 if you want to allow staying behind by a certain number of versions
+$versionsCounter = 0      # Internal counter for versions behind - do not modify
+
 # Start transcription
 Start-Transcript -path c:\client-install.log -append
 
@@ -22,6 +26,12 @@ $changeLogContent = Invoke-WebRequest -Uri $twingateClientChangelogRSS -UseBasic
 # Loop through the RSS feed items to find the latest Windows client version which should be the first match
 foreach ($item in $RSS.rss.channel.item) {
     if ($item.link -match "windows") {
+        if ($versionsToStayBehind -gt 0) { # Only apply if we're allowing versions behind
+            if ($versionsCounter -lt $versionsToStayBehind) {
+                $versionsCounter++
+                continue
+            }
+        }
         $changeLogVersion = $item.link -replace ".*#windows-(\d+-\d+)-release.*",'$1'
         $changeLogVersion = $changeLogVersion -replace "-","."
         break


### PR DESCRIPTION
For both detection and remediation (client installer) scripts, updated the logic to allow the admin to choose to "stay behind" versions.

If you set the flag to a number, such as 1 or 2, then it will look through the changelog and find the next 1 or 2 older versions from the latest.

So 0 is latest, 1 is next to latest, 2 is next-next to latest, and so on.

This allows admins to avoid the latest and greatest Windows Client when doing updates, or situations where they're installing a brand new released today client, and a local EDR may block usage due to the age of the client application.

Important that if you're using both of these scripts in Intune or any other MDM that supports a detect and remediate style deployment, that you set the same versions to stay behind in both before using the scripts together, otherwise you'll end up pulling down the wrong version.